### PR TITLE
In `compiling.py`, add option to return craft model

### DIFF
--- a/tracr/compiler/compiling.py
+++ b/tracr/compiler/compiling.py
@@ -25,7 +25,7 @@ from tracr.compiler import craft_model_to_transformer
 from tracr.compiler import expr_to_craft_graph
 from tracr.compiler import rasp_to_graph
 from tracr.compiler import validating
-from tracr.craft import bases
+from tracr.craft import bases, transformers
 from tracr.rasp import rasp
 
 
@@ -37,6 +37,8 @@ class TracrOutput:
   """The output of the tracr compiler."""
   model: assemble.AssembledTransformerModel
   graph: nx.DiGraph
+  basis = None
+  craft_model: transformers.SeriesWithResiduals = None
 
 
 def compile_rasp_to_model(
@@ -47,6 +49,7 @@ def compile_rasp_to_model(
     compiler_bos: str = COMPILER_BOS,
     compiler_pad: str = COMPILER_PAD,
     mlp_exactness: int = 100,
+    return_craft_model: bool = False,
 ) -> TracrOutput:
   """Compile a RASP program to transformer weights.
 
@@ -133,4 +136,5 @@ def compile_rasp_to_model(
   return TracrOutput(
       model=tracr_model,
       graph=graph,
+      craft_model=craft_model if return_craft_model else None,
   )


### PR DESCRIPTION
Craft model is necessary to construct a correspondence for use in the IIT-based ACD benchmark.